### PR TITLE
Add Apple API key restriction headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ func locationExample() {
 }
 ```
 
+### Using API Key Apple App Restrictions
+
+If your API key is configured with [Apple app restrictions](https://docs.aws.amazon.com/location/latest/developerguide/using-apikeys.html), the SDK automatically attaches the required `X-Apple-Bundle-Id` header to all API key requests made through the SDK clients. The SDK reads the bundle identifier from your app automatically.
+
+For MapLibre map tile requests, use `MapLibreHTTPProvider`:
+
+```swift
+import AmazonLocationiOSAuthSDK
+
+// Call before creating any MLNMapView
+MapLibreHTTPProvider.configureMapLibre()
+```
+
 ### Amazon Cognito
 
 Here is an example using the standalone `Places` SDK with the [Amazon Cognito](https://docs.aws.amazon.com/location/latest/developerguide/authenticating-using-cognito.html) authentication method:

--- a/Sources/AmazonLocationiOSAuthSDK/Client/ApiKeyAuthScheme.swift
+++ b/Sources/AmazonLocationiOSAuthSDK/Client/ApiKeyAuthScheme.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ClientRuntime
 import SmithyHTTPAuthAPI
 import Smithy
@@ -65,9 +66,11 @@ public class APIKeyInterceptor<InputType, OutputType>: Interceptor {
     public typealias ResponseType = HTTPResponse
     
     private var apiKey: String
+    private var bundleId: String?
 
     public init(apiKey: String) {
         self.apiKey = apiKey
+        self.bundleId = Bundle.main.bundleIdentifier
     }
 
     // Use the HTTP interceptor to inject the API key "key" query param into requests
@@ -85,16 +88,21 @@ public class APIKeyInterceptor<InputType, OutputType>: Interceptor {
             }
         }
         
+        let requestBuilder = context.getRequest().toBuilder()
+        
+        // Add Apple Bundle ID header for API key restrictions
+        if let bundleId = bundleId {
+            requestBuilder.withHeader(name: "X-Apple-Bundle-Id", value: bundleId)
+        }
+        
         // If the request was missing an apiKey, then we add it to the request
         // directly through the query parameters
         if (!apiKeyExists) {
             let apiKeyQueryItem = URIQueryItem(name: apiKeyName, value: apiKey)
-            
-            let requestBuilder = context.getRequest().toBuilder()
             requestBuilder.withQueryItem(apiKeyQueryItem)
-            
-            context.updateRequest(updated: requestBuilder.build())
         }
+        
+        context.updateRequest(updated: requestBuilder.build())
     }
 }
 

--- a/Sources/AmazonLocationiOSAuthSDK/Client/MapLibreHTTPProvider.swift
+++ b/Sources/AmazonLocationiOSAuthSDK/Client/MapLibreHTTPProvider.swift
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+/// Provides configuration for MapLibre network requests to include Apple app identity headers.
+/// This enables API key Apple app restrictions for map tile requests.
+///
+/// Usage:
+/// ```
+/// MapLibreHTTPProvider.configureMapLibre()
+/// ```
+///
+/// Call this before creating any MLNMapView or using MLNOfflineStorage.
+public class MapLibreHTTPProvider {
+    
+    /// Configures MapLibre's network session to include the X-Apple-Bundle-Id header
+    /// for API key Apple app restrictions on map tile requests.
+    public static func configureMapLibre() {
+        guard let bundleId = Bundle.main.bundleIdentifier else { return }
+        
+        let config = URLSessionConfiguration.default
+        config.httpAdditionalHeaders = [
+            "X-Apple-Bundle-Id": bundleId
+        ]
+        
+        // MLNNetworkConfiguration is from MapLibre - we use runtime to avoid hard dependency
+        if let networkConfigClass = NSClassFromString("MLNNetworkConfiguration") as? NSObject.Type,
+           let sharedManager = networkConfigClass.value(forKey: "sharedManager") as? NSObject {
+            sharedManager.setValue(config, forKey: "sessionConfiguration")
+        }
+    }
+}

--- a/Tests/AmazonLocationiOSAuthSDKTests/APIKeyInterceptorTests.swift
+++ b/Tests/AmazonLocationiOSAuthSDKTests/APIKeyInterceptorTests.swift
@@ -1,0 +1,74 @@
+import Testing
+import Foundation
+@testable import AmazonLocationiOSAuthSDK
+import SmithyHTTPAPI
+import ClientRuntime
+import Smithy
+
+@Suite("APIKeyInterceptor Tests") struct APIKeyInterceptorTests {
+    
+    @Test("Test bundle ID header is added to request") func testBundleIdHeaderAdded() async throws {
+        let interceptor = APIKeyInterceptor<String, String>(apiKey: "test-api-key")
+        let context = MockRequestContext()
+        
+        try await interceptor.modifyBeforeSigning(context: context)
+        
+        let updatedRequest = context.getRequest()
+        let bundleIdHeader = updatedRequest.headers.value(for: "X-Apple-Bundle-Id")
+        
+        if let expectedBundleId = Bundle.main.bundleIdentifier {
+            #expect(bundleIdHeader == expectedBundleId)
+        }
+    }
+    
+    @Test("Test API key query param is added when missing") func testApiKeyAdded() async throws {
+        let interceptor = APIKeyInterceptor<String, String>(apiKey: "test-api-key")
+        let context = MockRequestContext()
+        
+        try await interceptor.modifyBeforeSigning(context: context)
+        
+        let updatedRequest = context.getRequest()
+        let hasKey = updatedRequest.queryItems?.contains(where: { $0.name == "key" && $0.value == "test-api-key" }) ?? false
+        #expect(hasKey)
+    }
+    
+    @Test("Test API key not duplicated when already present") func testApiKeyNotDuplicated() async throws {
+        let interceptor = APIKeyInterceptor<String, String>(apiKey: "test-api-key")
+        let request = HTTPRequestBuilder()
+            .withHost("example.com")
+            .withPath("/test")
+            .withMethod(.get)
+            .withQueryItem(URIQueryItem(name: "key", value: "existing-key"))
+            .build()
+        let context = MockRequestContext(request: request)
+        
+        try await interceptor.modifyBeforeSigning(context: context)
+        
+        let updatedRequest = context.getRequest()
+        let keyItems = updatedRequest.queryItems?.filter { $0.name == "key" } ?? []
+        #expect(keyItems.count == 1)
+        #expect(keyItems.first?.value == "existing-key")
+    }
+}
+
+class MockRequestContext: MutableRequest {
+    typealias InputType = String
+    typealias OutputType = String
+    typealias RequestType = HTTPRequest
+    typealias ResponseType = HTTPResponse
+    
+    private var request: HTTPRequest
+    
+    init(request: HTTPRequest? = nil) {
+        self.request = request ?? HTTPRequestBuilder()
+            .withHost("example.com")
+            .withPath("/test")
+            .withMethod(.get)
+            .build()
+    }
+    
+    func getInput() -> String { return "" }
+    func getAttributes() -> Context { return Context(attributes: Attributes()) }
+    func getRequest() -> HTTPRequest { return request }
+    func updateRequest(updated: HTTPRequest) { self.request = updated }
+}


### PR DESCRIPTION
## Summary

Automatically attach `X-Apple-Bundle-Id` header to all API key authenticated requests. This enables customers to use API keys with Apple app restrictions without needing to manually set headers. The SDK reads the bundle identifier from the app automatically.

## Changes

- **`ApiKeyAuthScheme.swift`** — `APIKeyInterceptor` now attaches `X-Apple-Bundle-Id` header to all API key requests
- **`MapLibreHTTPProvider.swift`** — new helper to configure MapLibre's network session with the header for map tile requests
- **`README.md`** — added usage section for Apple app restrictions

## Testing

- Verified end-to-end on iOS simulator with an API key configured with Apple Bundle ID restriction
- Places API calls succeed with header present, fail without it
- Map tiles load correctly via MapLibreHTTPProvider
- API key with no restrictions still works with headers present (headers are safely ignored)